### PR TITLE
Configure types to skip schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,9 @@ Other supported options are:
     *   when set to `true`, the output uses the `$ref` field in OpenAPI spec to reference other schemas.
 *   `yaml`
     *   when set to `true`, the output is in yaml file.
+*   `include_description`
+    *   when set to `true`, the openapi schema will include descriptions, generated from the proto message comment.
+*   `enum_as_int_or_string`
+    *   when set to `true`, the openapi schema will include `x-kubernetes-int-or-string` on enums.
+*   `additional_empty_schemas`
+    *   a `+` separated list of message names (`core.solo.io.Status`), whose generated schema should be an empty object that accepts all values.

--- a/changelog/v0.0.5/support-empty-schema.yaml
+++ b/changelog/v0.0.5/support-empty-schema.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: Support injecting a set of message names to generate empty validation schema
+    issueLink: https://github.com/solo-io/gloo/issues/4789
+    resolvesIssue: false

--- a/changelog/v0.1.0/support-empty-schema.yaml
+++ b/changelog/v0.1.0/support-empty-schema.yaml
@@ -1,5 +1,5 @@
 changelog:
-  - type: FIX
+  - type: BREAKING_CHANGE
     description: Support injecting a set of message names to generate empty validation schema
     issueLink: https://github.com/solo-io/gloo/issues/4789
     resolvesIssue: false

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,16 @@
 module github.com/solo-io/protoc-gen-openapi
 
-go 1.16
+go 1.18
 
 require (
 	github.com/getkin/kin-openapi v0.80.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/golang/protobuf v1.3.2
+)
+
+require (
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/solo-io/protoc-gen-openapi/pkg/protocgen"
@@ -49,9 +48,9 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 	singleFile := false
 	yaml := false
 	useRef := false
-	maxCharactersInDescription := 0
 	includeDescription := true
 	enumAsIntOrString := false
+	var messagesWithEmptySchema []string
 
 	p := extractParams(request.GetParameter())
 	for k, v := range p {
@@ -87,12 +86,6 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 			default:
 				return nil, fmt.Errorf("unknown value '%s' for use_ref", v)
 			}
-		} else if k == "max_description_characters" {
-			var err error
-			maxCharactersInDescription, err = strconv.Atoi(v)
-			if err != nil {
-				return nil, fmt.Errorf("unknown value '%s' for max_description_characters", v)
-			}
 		} else if k == "include_description" {
 			switch strings.ToLower(v) {
 			case "true":
@@ -111,6 +104,8 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 			default:
 				return nil, fmt.Errorf("unknown value '%s' for enum_as_int_or_string", v)
 			}
+		} else if k == "empty_schema" {
+			messagesWithEmptySchema = strings.Split(v, ",")
 		} else {
 			return nil, fmt.Errorf("unknown argument '%s' specified", k)
 		}
@@ -128,11 +123,18 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 	}
 
 	descriptionConfiguration := &DescriptionConfiguration{
-		MaxDescriptionCharacters:   maxCharactersInDescription,
 		IncludeDescriptionInSchema: includeDescription,
 	}
 
-	g := newOpenAPIGenerator(m, perFile, singleFile, yaml, useRef, descriptionConfiguration, enumAsIntOrString)
+	g := newOpenAPIGenerator(
+		m,
+		perFile,
+		singleFile,
+		yaml,
+		useRef,
+		descriptionConfiguration,
+		enumAsIntOrString,
+		messagesWithEmptySchema)
 	return g.generateOutput(filesToGen)
 }
 

--- a/main.go
+++ b/main.go
@@ -104,7 +104,7 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 			default:
 				return nil, fmt.Errorf("unknown value '%s' for enum_as_int_or_string", v)
 			}
-		} else if k == "empty_schema" {
+		} else if k == "additional_empty_schema" {
 			messagesWithEmptySchema = strings.Split(v, "+")
 		} else {
 			return nil, fmt.Errorf("unknown argument '%s' specified", k)

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func generate(request plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorRespons
 				return nil, fmt.Errorf("unknown value '%s' for enum_as_int_or_string", v)
 			}
 		} else if k == "empty_schema" {
-			messagesWithEmptySchema = strings.Split(v, ",")
+			messagesWithEmptySchema = strings.Split(v, "+")
 		} else {
 			return nil, fmt.Errorf("unknown argument '%s' specified", k)
 		}

--- a/openapiGenerator.go
+++ b/openapiGenerator.go
@@ -130,6 +130,11 @@ func newOpenAPIGenerator(
 	}
 }
 
+// buildCustomSchemasByMessageName name returns a mapping of message name to a pre-defined openapi schema
+// It includes:
+//	1. `specialSoloTypes`, a set of pre-defined schemas
+//  2. `messagesWithEmptySchema`, a list of messages that are injected at runtime that should contain
+//  and empty schema which accepts and preserves all fields
 func buildCustomSchemasByMessageName(messagesWithEmptySchema []string) map[string]openapi3.Schema {
 	schemasByMessageName := make(map[string]openapi3.Schema)
 


### PR DESCRIPTION
# Context
## Introduce `additional_empty_schema`
This field expects a list of message names, separate by the '+' delimiter.

This is a quick and easy way to inject a set of messages who schema should be created empty. This case is helpful when there are recursive definitions, or the time to generate the schema is too long.

An alternative would be to support message level options. Our hope is that this library is eventually deprecated in favor of https://github.com/solo-io/cue, so I avoided an extensive change.

## Remove `max_description_characters`
This field is no longer used. Validation schema descriptions are not useful, and are removed entirely using the `include_description` option.

# Testing
The following solo-kit imports this change, and adds a test to verify: https://github.com/solo-io/solo-kit/pull/482