### PR TITLE
Standard json type mapped from protobuf `int64`  is `string`

### DIFF
--- a/openapiGenerator.go
+++ b/openapiGenerator.go
@@ -372,7 +372,7 @@ func (g *openapiGenerator) generateSoloMessageSchema(message *protomodel.Message
 }
 
 func (g *openapiGenerator) generateSoloInt64Schema() *openapi3.Schema {
-	schema := openapi3.NewInt64Schema()
+	schema := openapi3.NewStringSchema()
 	schema.ExtensionProps = openapi3.ExtensionProps{
 		Extensions: map[string]interface{}{
 			"x-kubernetes-int-or-string": true,


### PR DESCRIPTION
> JSON value will be a decimal string. Either numbers or strings are accepted.

https://protobuf.dev/programming-guides/proto3/#json

Users of protojson have also been confused by encodings for int64 types being strings.
https://github.com/golang/protobuf/issues/1414

This PR should ensure that the generated docs are in line with the protobuf standard.
