### PR TITLE
test: fix bug in test and update test manifest

### DIFF
--- a/changelog/v0.1.2/fix-test.yaml
+++ b/changelog/v0.1.2/fix-test.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: Fix bug in test pertaining to incorrect validation of expected files.
+    issueLink: https://github.com/solo-io/protoc-gen-openapi/issues/18
+    resolvesIssue: true

--- a/integration_test.go
+++ b/integration_test.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -27,7 +26,7 @@ import (
 const goldenDir = "testdata/golden/"
 
 func TestOpenAPIGeneration(t *testing.T) {
-	var testcases = []struct {
+	testcases := []struct {
 		name       string
 		perPackage bool
 		genOpts    string
@@ -55,7 +54,7 @@ func TestOpenAPIGeneration(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			tempDir, err := ioutil.TempDir("", "openapi-temp")
+			tempDir, err := os.MkdirTemp("", "openapi-temp")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -93,7 +92,7 @@ func TestOpenAPIGeneration(t *testing.T) {
 				wantPath := goldenDir + file
 				// we are looking for the same file name in the generated path
 				genPath := filepath.Join(tempDir, filepath.Base(wantPath))
-				got, err := ioutil.ReadFile(genPath)
+				got, err := os.ReadFile(genPath)
 				if err != nil {
 					if os.IsNotExist(err) {
 						t.Fatalf("expected generated file %v does not exist: %v", genPath, err)
@@ -102,13 +101,13 @@ func TestOpenAPIGeneration(t *testing.T) {
 					}
 				}
 
-				want, err := ioutil.ReadFile(wantPath)
+				want, err := os.ReadFile(wantPath)
 				if err != nil {
 					t.Errorf("error reading the golden file: %v", err)
 				}
 
 				if bytes.Equal(got, want) {
-					return
+					continue
 				}
 
 				cmd := exec.Command("diff", "-u", wantPath, genPath)

--- a/testdata/golden/testpkg2.json
+++ b/testdata/golden/testpkg2.json
@@ -4,27 +4,21 @@
     "schemas": {
       "testpkg2.AEnum": {
         "enum": [
-          [
-            "ONE",
-            "TWO",
-            "THREE"
-          ]
+          "ONE",
+          "TWO",
+          "THREE"
         ],
         "type": "string"
       },
       "testpkg2.MessageOneOf": {
         "properties": {
-          "port": {
-            "oneOf": [
-              {
-                "description": "Valid port number",
-                "format": "int32",
-                "type": "integer"
-              },
-              {
-                "type": "string"
-              }
-            ]
+          "name": {
+            "type": "string"
+          },
+          "number": {
+            "description": "Valid port number",
+            "format": "int32",
+            "type": "integer"
           }
         },
         "type": "object"
@@ -32,30 +26,31 @@
       "testpkg2.Test3": {
         "description": "Test3 is a message that I use for testing.",
         "properties": {
-          "OneofField": {
-            "oneOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "string"
-              }
-            ]
-          },
           "aEnum": {
             "enum": [
-              [
-                "ONE",
-                "TWO",
-                "THREE"
-              ]
+              "ONE",
+              "TWO",
+              "THREE"
             ],
+            "type": "string"
+          },
+          "deprecate": {
             "type": "string"
           },
           "field1": {
             "description": "field1 is a field",
             "format": "int32",
             "type": "integer"
+          },
+          "field17": {
+            "format": "int64",
+            "type": "integer",
+            "x-kubernetes-int-or-string": true
+          },
+          "field18": {
+            "format": "int64",
+            "type": "integer",
+            "x-kubernetes-int-or-string": true
           },
           "field3": {
             "type": "number"
@@ -98,20 +93,22 @@
           "messageOneOfField": {
             "description": "messageoneof comment",
             "properties": {
-              "port": {
-                "oneOf": [
-                  {
-                    "description": "Valid port number",
-                    "format": "int32",
-                    "type": "integer"
-                  },
-                  {
-                    "type": "string"
-                  }
-                ]
+              "name": {
+                "type": "string"
+              },
+              "number": {
+                "description": "Valid port number",
+                "format": "int32",
+                "type": "integer"
               }
             },
             "type": "object"
+          },
+          "oneoffield1": {
+            "type": "string"
+          },
+          "oneoffield2": {
+            "type": "string"
           },
           "str": {
             "description": "an array of strings",
@@ -150,7 +147,7 @@
   },
   "info": {
     "title": "OpenAPI Spec for Solo APIs.",
-    "version": ""
+    "version": "testpkg2"
   },
   "paths": null
 }


### PR DESCRIPTION
This fixes a bug in the test where if multiple files are to be validated by the test, the test incorrectly `returns` from a `for` loop that asserts the correctness of multiple expected files when the first expected file succeeds validation. As a result, the manifest for testpkg2.json was never updated as the code evolved, and is incorrect in its current form.
BOT NOTES: 
resolves https://github.com/solo-io/protoc-gen-openapi/issues/18