### PR TITLE
Update go.mod to use full go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/protoc-gen-openapi
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/getkin/kin-openapi v0.80.0


### PR DESCRIPTION
This fixes an issue better described here https://github.com/golang/go/issues/65568 where GOTOOLCHAIN env var gets an invalid value causing the following error when trying to build the project:
```
go: downloading go1.22 (linux/amd64) 
go: download go1.22: zip: not a valid zip file
```

This fix is suggested in the previously linked issue.