### PR TITLE
Add support for proto3 optional fields in protoc-gen-openapi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build: install-deps
 run:
 	rm -fr $(OUTPUTDIR)
 	mkdir -p $(OUTPUTDIR)
-        protoc --plugin=./$(BINDIR)/protoc-gen-openapi --openapi_out=single_file=true,use_ref=true:$(OUTPUTDIR)/. -Itestdata testdata/testpkg/test1.proto testdata/testpkg/test2.proto testdata/testpkg/test6.proto testdata/testpkg2/test3.proto testdata/testpkg/test_proto3_optional.proto
+	protoc --plugin=./$(BINDIR)/protoc-gen-openapi --openapi_out=single_file=true,use_ref=true:$(OUTPUTDIR)/. -Itestdata testdata/testpkg/test1.proto testdata/testpkg/test2.proto testdata/testpkg/test6.proto testdata/testpkg2/test3.proto testdata/testpkg/test_proto3_optional.proto
 
 gotest:
 	PATH=$(BINDIR):$(PATH) go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build: install-deps
 run:
 	rm -fr $(OUTPUTDIR)
 	mkdir -p $(OUTPUTDIR)
-	protoc --plugin=./$(BINDIR)/protoc-gen-openapi --openapi_out=single_file=true,use_ref=true:$(OUTPUTDIR)/. -Itestdata testdata/testpkg/test1.proto testdata/testpkg/test2.proto testdata/testpkg/test6.proto testdata/testpkg2/test3.proto
+        protoc --plugin=./$(BINDIR)/protoc-gen-openapi --openapi_out=single_file=true,use_ref=true:$(OUTPUTDIR)/. -Itestdata testdata/testpkg/test1.proto testdata/testpkg/test2.proto testdata/testpkg/test6.proto testdata/testpkg2/test3.proto testdata/testpkg/test_proto3_optional.proto
 
 gotest:
 	PATH=$(BINDIR):$(PATH) go test -v ./...

--- a/openapiGenerator.go
+++ b/openapiGenerator.go
@@ -424,9 +424,13 @@ func (g *openapiGenerator) generateMessageSchema(message *protomodel.MessageDesc
 
 	oneOfFields := make(map[int32][]string)
 	var requiredFields []string
+		// Handle proto3 optional fields - they should not be required
 	for _, field := range message.Fields {
+		if field.Proto3Optional != nil && *field.Proto3Optional {
 		repeated := field.IsRepeated()
+			// Proto3 optional fields are never required
 		fieldName := g.fieldName(field)
+		} else if g.markerRegistry.IsRequired(fieldRules) {
 		fieldDesc := g.generateDescription(field)
 		fieldRules := g.validationRules(field)
 
@@ -436,8 +440,9 @@ func (g *openapiGenerator) generateMessageSchema(message *protomodel.MessageDesc
 			oneOfFields[idx] = append(oneOfFields[idx], fieldName)
 		}
 
-		if g.markerRegistry.IsRequired(fieldRules) {
+			// Field is required by marker
 			requiredFields = append(requiredFields, fieldName)
+		}
 		}
 
 		schemaType := g.markerRegistry.GetSchemaType(fieldRules, markers.TargetField)
@@ -827,3 +832,4 @@ func isIgnoredKubeMarker(regexp *regexp.Regexp, l string) bool {
 
 	return regexp.MatchString(l)
 }
+


### PR DESCRIPTION
This PR addresses Issue #28 (https://github.com/solo-io/protoc-gen-openapi/issues/28)) 
which highlights a lack of support for optional fields in proto3 syntax.

1. The issue is that proto3 optional fields are not supported. The fix adds detection of proto3 optional fields using the Proto3Optional field descriptor property and ensures they are not marked as required in the OpenAPI schema, which correctly reflects their optional nature.

2. Changes in MakeFile - Added a test proto file with proto3 optional fields to the protoc command to ensure the plugin can handle proto3 optional fields during testing and development