### PR TITLE
feat: generate enums as integer types

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -139,6 +139,16 @@ func TestOpenAPIGeneration(t *testing.T) {
 			},
 			wantFiles: []string{"test10/openapiv3.yaml"},
 		},
+		{
+			name:       "Test enum with x-enumNames",
+			id:         "test11",
+			perPackage: false,
+			genOpts:    "yaml=true,single_file=true,use_int_enums=true,enum_names_extensions=x-enumNames;x-enum-values",
+			inputFiles: map[string][]string{
+				"test11": {"./testdata/test11/enums.proto"},
+			},
+			wantFiles: []string{"test11/openapiv3.yaml"},
+		},
 	}
 
 	for _, tc := range testcases {

--- a/main.go
+++ b/main.go
@@ -51,10 +51,12 @@ func generate(request pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorRes
 	includeDescription := true
 	multilineDescription := false
 	enumAsIntOrString := false
+	enumAsInt := false
 	protoOneof := false
 	intNative := false
 	disableKubeMarkers := false
 
+	var enumNamesExtensions []string
 	var messagesWithEmptySchema []string
 	var ignoredKubeMarkerSubstrings []string
 
@@ -118,6 +120,20 @@ func generate(request pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorRes
 				enumAsIntOrString = false
 			default:
 				return nil, fmt.Errorf("unknown value '%s' for enum_as_int_or_string", v)
+			}
+		} else if k == "use_int_enums" {
+			switch strings.ToLower(v) {
+			case "true":
+				enumAsInt = true
+			case "false":
+				enumAsInt = false
+			default:
+				return nil, fmt.Errorf("unknown value '%s' for enum_as_int", v)
+			}
+		} else if k == "enum_names_extensions" {
+			enumNamesExtensions = strings.Split(v, ";")
+			if len(enumNamesExtensions) == 0 {
+				return nil, fmt.Errorf("cant use '%s' as enum_names_extensions, provide a semicolon separated list", v)
 			}
 		} else if k == "proto_oneof" {
 			switch strings.ToLower(v) {
@@ -185,6 +201,8 @@ func generate(request pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorRes
 		useRef,
 		descriptionConfiguration,
 		enumAsIntOrString,
+		enumAsInt,
+		enumNamesExtensions,
 		messagesWithEmptySchema,
 		protoOneof,
 		intNative,

--- a/testdata/golden/test11/openapiv3.yaml
+++ b/testdata/golden/test11/openapiv3.yaml
@@ -1,0 +1,35 @@
+components:
+  schemas:
+    test11.AnotherEnum:
+      enum:
+      - 0
+      - 1
+      - 2
+      type: integer
+      x-enum-values:
+      - ANOTHER_UNSPECIFIED
+      - ANOTHER_SOME_NAME
+      - ANOTHER_ANOTHER_NAME
+      x-enumNames:
+      - ANOTHER_UNSPECIFIED
+      - ANOTHER_SOME_NAME
+      - ANOTHER_ANOTHER_NAME
+    test11.MyProtoEnum:
+      enum:
+      - 0
+      - 1
+      - 2
+      type: integer
+      x-enum-values:
+      - MY_PROTO_UNSPECIFIED
+      - MY_PROTO_SOME_NAME
+      - MY_PROTO_ANOTHER_NAME
+      x-enumNames:
+      - MY_PROTO_UNSPECIFIED
+      - MY_PROTO_SOME_NAME
+      - MY_PROTO_ANOTHER_NAME
+info:
+  title: OpenAPI Spec for Solo APIs.
+  version: ""
+openapi: 3.0.1
+paths: null

--- a/testdata/test11/enums.proto
+++ b/testdata/test11/enums.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package test11;
+
+enum MyProtoEnum {
+  MY_PROTO_UNSPECIFIED = 0;
+  MY_PROTO_SOME_NAME = 1;
+  MY_PROTO_ANOTHER_NAME = 2;
+}
+
+enum AnotherEnum {
+  ANOTHER_UNSPECIFIED = 0;
+  ANOTHER_SOME_NAME = 1;
+  ANOTHER_ANOTHER_NAME = 2;
+}


### PR DESCRIPTION
Add 2 new options for generating protobuf enums as integer types.
1. `use_int_enums=true`: generates enums as type: integer with the respective protobuf numbers
2. `enum_names_extensions=x-enumNames;x-enum-varnames`: generates extensions in the enums with the names of enums used for the openapi generators to generate better enums.